### PR TITLE
Fix of fix second Passenger gets stuck

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
@@ -532,7 +532,7 @@ struct npc_salvaged_siege_engine : public VehicleAI
             {
                 if (Unit* turret = vehicle->GetPassenger(7))
                 {
-                    if (Vehicle* turretVehicle = me->GetVehicleKit())
+                    if (Vehicle* turretVehicle = vehicle->GetVehicleKit())
                     {
                         if (!turretVehicle->IsVehicleInUse())
                         {


### PR DESCRIPTION
When second passenger wants enter siege engine player gets stuck in vehicle nad doesnt enter turret.
